### PR TITLE
Fix error that occurs when deleting non-destroyed_at parent that has …

### DIFF
--- a/lib/destroyed_at/has_many_association.rb
+++ b/lib/destroyed_at/has_many_association.rb
@@ -3,7 +3,7 @@ module DestroyedAt
     def delete_records(records, method)
       if method == :destroy
         records.each do |r|
-          if r.respond_to?(:destroyed_at)
+          if r.respond_to?(:destroyed_at) && owner.respond_to?(:destroyed_at)
             r.destroy(owner.destroyed_at)
           else
             r.destroy

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -236,6 +236,16 @@ describe 'non destroyed-at models' do
     assert_equal(0, Person.count, 'Person must be zero')
     assert_equal(0, Pet.count, 'Pet must be zero')
   end
+
+  it 'can destroy has_many dependants' do
+    author = Author.create!
+    author.posts.create!
+
+    author.destroy
+
+    assert_equal(0, Author.count, 'Author must be zero')
+    assert_equal(0, Post.count, 'Post must be zero')
+  end
 end
 
 describe 'destroying a child that destroys its parent on destroy' do
@@ -249,3 +259,4 @@ describe 'destroying a child that destroys its parent on destroy' do
     assert_equal(0, DestructiveChild.count, 'DestructiveChild must be zero')
   end
 end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,7 +41,7 @@ ActiveRecord::Base.connection.execute(%{CREATE TABLE pets (id INTEGER PRIMARY KE
 ActiveRecord::Base.connection.execute(%{CREATE TABLE likes (id INTEGER PRIMARY KEY, likeable_id INTEGER, likeable_type TEXT, destroyed_at DATETIME);})
 
 class Author < ActiveRecord::Base
-  has_many :posts
+  has_many :posts, dependent: :destroy
   has_one :avatar, dependent: :destroy
 end
 


### PR DESCRIPTION
…a destroyed_at has_many child marked dependent => destroy
